### PR TITLE
cert-manager: fast-forward to upstream 641edb90

### DIFF
--- a/stable/cert-manager/templates/00-namespace.yaml
+++ b/stable/cert-manager/templates/00-namespace.yaml
@@ -1,0 +1,6 @@
+{{ if .Values.createNamespaceResource }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/stable/cert-manager/templates/NOTES.txt
+++ b/stable/cert-manager/templates/NOTES.txt
@@ -6,10 +6,10 @@ or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
 More information on the different types of issuers and how to configure them
 can be found in our documentation:
 
-https://cert-manager.readthedocs.io/en/latest/reference/issuers.html
+http://cert-manager.readthedocs.io/en/latest/reference/issuers.html
 
 For information on how to configure cert-manager to automatically provision
 Certificates for Ingress resources, take a look at the `ingress-shim`
 documentation:
 
-https://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html
+http://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html

--- a/stable/cert-manager/templates/deployment.yaml
+++ b/stable/cert-manager/templates/deployment.yaml
@@ -30,11 +30,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-          # This is currently commented out until the 0.3 release of
-          # cert-manager, as it results in a breaking change (users will need
-          # to move credentials/acme private keys from kube-system into the
-          # same namespace cert-manager is deployed into.
-          # - --cluster-resource-namespace=$(POD_NAMESPACE)
+          - --cluster-resource-namespace=$(POD_NAMESPACE)
         {{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | indent 10 }}
         {{- end }}


### PR DESCRIPTION
* f117e6e8 Merge branch 'master' into patch-1
* Add Endpoints back into the cert-manager RBAC policy (jetstack/cert-manager#343)
* Set default cluster resource namespace to current pod namespace (jetstack/cert-manager#329)
* Add default shortNames to certificates CRD (jetstack/cert-manager#312)
* Use cert-manager & boulder installed via helm in e2e tests. Run tests with Prow. (jetstack/cert-manager#216)